### PR TITLE
chore: update npm-run-all to npm-run-all2

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -22,7 +22,7 @@
                 "babel-plugin-istanbul": "^6.0.0",
                 "codecov": "^3.8.3",
                 "jest-cli": "^27.1.1",
-                "npm-run-all": "^4.1.2",
+                "npm-run-all2": "^6.1.1",
                 "opn-cli": "^3.1.0",
                 "raw-loader": "^0.5.1",
                 "webpack": "^4.16.3",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "babel-plugin-istanbul": "^6.0.0",
         "codecov": "^3.8.3",
         "jest-cli": "^27.1.1",
-        "npm-run-all": "^4.1.2",
+        "npm-run-all2": "^6.1.1",
         "opn-cli": "^3.1.0",
         "raw-loader": "^0.5.1",
         "webpack": "^4.16.3",


### PR DESCRIPTION
This PR aims to replace `npm-run-all` which is no longer maintained (https://github.com/mysticatea/npm-run-all - last release November 2018).
The replacement `npm-run-all2` can be used as a replacement that is still actively maintained (https://github.com/bcomnes/npm-run-all2 - last release October 2023)


> npm-run-all2 why?
> 
> A maintenance fork of npm-run-all. npm-run-all2 is a fork of npm-run-all with dependabot updates, release automation enabled and some troublesome babel stuff removed to further reduce maintenance burden. Hopefully this labor can upstream some day when mysticatea returns, but until then, welcome aboard!
> 

Please note that I created this PR semi-automatically across all applicable projects in https://github.com/camunda and https://github.com/camunda-community-hub

Feel free to ping me if you find any issue with it or simply ignore it.